### PR TITLE
Get github action workflow working

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,10 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6
     - name: Install dependencies

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -5,7 +5,7 @@
 # This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
 # For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
 
-name: Ruby
+name: Tests
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 = Deadlock Retry
 
+![Tests](https://github.com/timothyp/deadlock_retry/workflows/Tests/badge.svg)
+
 Deadlock retry allows the database adapter (currently only tested with the
 MySQLAdapter) to retry transactions that fall into deadlock. It will retry
 such transactions three times before finally failing.

--- a/deadlock_retry.gemspec
+++ b/deadlock_retry.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.homepage = %q{http://github.com/mperham/deadlock_retry}
   s.require_paths = ["lib"]
+  s.add_development_dependency 'rake'
+  s.add_development_dependency 'test-unit'
   s.add_development_dependency 'mocha', '~>1.0'
   s.add_development_dependency 'activerecord', ENV['ACTIVERECORD_VERSION'] || ' ~>4.0'
 end


### PR DESCRIPTION
Switched to setup-ruby@v1 action as recommended instead of the specification using a commit hash which was what it had defaulted to on creating the workflow file (and which was broken due to set-env deprecation).  Also had to specify a couple of dev dependencies.